### PR TITLE
Fix bug with missing externs causing the task to break.

### DIFF
--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -45,7 +45,11 @@ module.exports = function(grunt) {
 
     // Build command line.
     command += ' --js ' + data.js.join(' --js ');
-    command += ' --externs ' + data.externs.join(' --externs ');
+    
+    if (data.js.length) {
+      // Add --externs flag only if valid externs are present.
+      command += ' --externs ' + data.externs.join(' --externs ');
+    }
 
     if (data.jsOutputFile) {
       command += ' --js_output_file ' + data.jsOutputFile;


### PR DESCRIPTION
If there are no externs specified via options, the task breaks.
The generated command should not look like this:

$ java -jar /path/to/closure-compiler/build/compiler.jar --js file1.js --js file2.js --externs

This change skips adding the --externs flag if no externs have been specified.
