### PR TITLE
Allow non-value closure-compiler options

### DIFF
--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -71,6 +71,8 @@ module.exports = function(grunt) {
     for (var directive in data.options) {
       if (Array.isArray(data.options[directive])) {
         command += ' --' + directive + ' ' + data.options[directive].join(' --' + directive + ' ');
+      } else if (data.options[directive] === null) {
+        command += ' --' + directive;
       } else {
         command += ' --' + directive + ' ' + String(data.options[directive]);
       }


### PR DESCRIPTION
In one of [my projects](https://github.com/klipstein/tooling-example/blob/master/grunt.js#L30-31) I'm using grunt-closure-compiler where I want to use closure-compiler options which do not require any values.

This pull request allows to pass `null` to the grunt-closure-compiler options when no value needs to be passed to the closure-compiler option, e.g. :

``` js
'closure-compiler': {
  options: {
    transform_amd_modules: null,
    process_common_js_modules: null
  }
}
```
