### PR TITLE
maxBuffer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ grunt.initConfig({
       closurePath: '/src/to/closure-compiler',
       js: 'static/src/frontend.js',
       jsOutputFile: 'static/js/frontend.min.js',
+      maxBuffer: 500
       options: {
         compilation_level: 'ADVANCED_OPTIMIZATIONS',
         language_in: 'ECMASCRIPT5_STRICT'
@@ -40,6 +41,11 @@ grunt.initConfig({
 `js` property is always required.
 
 If `jsOutputFile` property is set, the script will be minified and saved to the file specified. Otherwise it will be output to the command line.
+
+`maxBuffer` property
+
+If the buffer returned by closure compiler is more than 200kb, you will get an error saying "maxBuffer exceeded". To prevent this, you can set the maxBuffer to the preffered size you want (in kb)
+
 
 Optionally, several parameters can be passed to `options` object.
 

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -79,7 +79,7 @@ module.exports = function(grunt) {
     }
 
     // Minify WebGraph class.
-    exec(command, function(err, stdout, stderr) {
+    exec(command, { maxBuffer: data.maxBuffer*1024 }, function(err, stdout, stderr) {
       if (err) {
         grunt.warn(err);
         done(false);


### PR DESCRIPTION
If the buffer returned by closure compiler is more than 200kb, you will get an error saying "maxBuffer exceeded". To prevent this, you can set the maxBuffer to the preffered size you want (in kb)
