### PR TITLE
removing 'build' from the directory

### DIFF
--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
       return false;
     }
 
-    var command = 'java -jar ' + closurePath + '/build/compiler.jar';
+    var command = 'java -jar ' + closurePath + '/closure.jar';
 
     data.js = grunt.file.expandFiles(data.js);
 


### PR DESCRIPTION
i'm specifying exactly the directory closure.jar can be found in, but this is adding `/build/` to the path.
