### PR TITLE
Put argument value in quotes

### DIFF
--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -68,13 +68,14 @@ module.exports = function(grunt) {
       }
     }
 
+
     for (var directive in data.options) {
       if (Array.isArray(data.options[directive])) {
         command += ' --' + directive + ' ' + data.options[directive].join(' --' + directive + ' ');
       } else if (data.options[directive] === undefined || data.options[directive] === null) {
         command += ' --' + directive;
       } else {
-        command += ' --' + directive + ' ' + String(data.options[directive]);
+        command += ' --' + directive + ' "' + String(data.options[directive]) + '"';
       }
     }
 


### PR DESCRIPTION
Using output_wrapper creates an error without quotes:

```
System:shield.js devinrhode2$ grunt closure-compiler
{ Shield: 
   { js: [ 'src/Shield.js', 'src/lodash.custom.js' ],
     jsOutputFile: 'dist/Shield.min.js',
     maxBuffer: 500,
     options: 
      { compilation_level: 'SIMPLE_OPTIMIZATIONS',
        language_in: 'ECMASCRIPT3',
        output_wrapper: '(function() {%output%})();',
        create_source_map: 'dist/Shield.min.map' } } }
Running "closure-compiler:Shield" (closure-compiler) task
Warning: Command failed: /bin/sh: -c: line 0:
  syntax error near unexpected token `('
/bin/sh: -c: line 0:
`java -jar /usr/local/Cellar/closure-compiler/20120917/libexec/build/compiler.jar
  --js src/Shield.js --js src/lodash.custom.js --js_output_file dist/Shield.min.js
  --compilation_level SIMPLE_OPTIMIZATIONS --language_in ECMASCRIPT3
  --output_wrapper (function() {%output%})(); --create_source_map dist/Shield.min.map'
 Use --force to continue.

Aborted due to warnings.
```

Notice the `syntax error near unexpected token '('` and
`java -jar ..compiler.jar .. --output_wrapper (function() {%output%})();`

But with quotes, there are no errors:

```
System:shield.js devinrhode2$ grunt closure-compiler
{ Shield: 
   { js: [ 'src/Shield.js', 'src/lodash.custom.js' ],
     jsOutputFile: 'dist/Shield.min.js',
     maxBuffer: 500,
     options: 
      { compilation_level: 'SIMPLE_OPTIMIZATIONS',
        language_in: 'ECMASCRIPT3',
        output_wrapper: '(function() {%output%})();',
        create_source_map: 'dist/Shield.min.map' } } }
Running "closure-compiler:Shield" (closure-compiler) task
Compressed size: 1.90 kb gzipped (1949 bytes).
A report is saved in dist/Shield.min.js.report.txt.

Done, without errors.
System:shield.js devinrhode2$
```
