### PR TITLE
Make report file optional [upstream]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-closure-compiler",
   "description": "A Grunt task for Closure Compiler.",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "homepage": "https://github.com/gmarty/grunt-closure-compiler",
   "author": {
     "name": "Guillaume Marty",

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -113,8 +113,10 @@ module.exports = function(grunt) {
           });
 
         });
-      } else if (data.report) {
-        grunt.log.error(stderr);
+      } else {
+        if (data.report) {
+          grunt.log.error(stderr);
+        }
         done();
       }
 

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -48,7 +48,10 @@ module.exports = function(grunt) {
 
     if (data.jsOutputFile) {
       command += ' --js_output_file ' + data.jsOutputFile;
-      reportFile = data.jsOutputFile + '.report.txt';
+    }
+
+    if (data.reportFile) {
+      reportFile = data.reportFile;
     }
 
     if (data.externs) {
@@ -110,6 +113,8 @@ module.exports = function(grunt) {
           });
 
         });
+      } else if (data.report) {
+        grunt.log.error(stderr);
       }
 
     });

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -115,6 +115,7 @@ module.exports = function(grunt) {
         });
       } else if (data.report) {
         grunt.log.error(stderr);
+        done();
       }
 
     });


### PR DESCRIPTION
I find it better to give the user the option to choose the location of the report file. I also added an option to send the closure report to the grunt.log.error output
