### PR TITLE
When asking for a closure path, we expect .jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ grunt.initConfig({
 });
 ```
 
-`closurePath` is required if you choose not to set up the `CLOSURE_PATH` environment variable. In this case, it should point to the install dir of Closure Compiler (not the subdirectory where the `compiler.jar` file is located).
+`closurePath` is required if you choose not to set up the `CLOSURE_PATH` environment variable. In this case, it should point to `compiler.jar` from closure compiler.
 
 `js` property is always required.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-closure-compiler",
   "description": "A Grunt task for Closure Compiler.",
-  "version": "0.0.17",
+  "version": "0.1.0",
   "homepage": "https://github.com/gmarty/grunt-closure-compiler",
   "author": {
     "name": "Guillaume Marty",

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
       return false;
     }
 
-    var command = 'java -jar ' + closurePath + '/build/compiler.jar';
+    var command = 'java -jar ' + closurePath;
 
     data.js = grunt.file.expand(data.js);
 


### PR DESCRIPTION
Because you don't know how is the .jar installed on the system.

It could be a git clone but in most cases, it will be the .zip google
gives: https://developers.google.com/closure/compiler/ (Download the
application = zip).

Forcing the user to follow a directory structure is not needed.
