### PR TITLE
Report file optional again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-closure-compiler",
   "description": "A Grunt task for Closure Compiler.",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "homepage": "https://github.com/gmarty/grunt-closure-compiler",
   "author": {
     "name": "Guillaume Marty",

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -48,11 +48,7 @@ module.exports = function(grunt) {
 
     if (data.jsOutputFile) {
       command += ' --js_output_file ' + data.jsOutputFile;
-      if ('reportFile' in data) {
-        reportFile = data.reportFile;
-      } else {
-        reportFile = data.jsOutputFile + '.report.txt';
-      }
+      reportFile = data.reportFile || data.jsOutputFile + '.report.txt';
     }
 
     if (data.externs) {
@@ -102,16 +98,20 @@ module.exports = function(grunt) {
             done(false);
           }
 
-          // Write compile report to a file.
-          fs.writeFile(reportFile, stderr, function(err) {
-            if (err) {
-              grunt.warn(err);
-              done(false);
-            }
-
-            grunt.log.writeln('A report is saved in ' + reportFile + '.');
+          if (data.noreport) {
             done();
-          });
+          } else {
+            // Write compile report to a file.
+            fs.writeFile(reportFile, stderr, function(err) {
+              if (err) {
+                grunt.warn(err);
+                done(false);
+              }
+
+              grunt.log.writeln('A report is saved in ' + reportFile + '.');
+              done();
+            });
+          }
 
         });
       } else {

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -48,10 +48,11 @@ module.exports = function(grunt) {
 
     if (data.jsOutputFile) {
       command += ' --js_output_file ' + data.jsOutputFile;
-    }
-
-    if (data.reportFile) {
-      reportFile = data.reportFile;
+      if ('reportFile' in data) {
+        reportFile = data.reportFile;
+      } else {
+        reportFile = data.jsOutputFile + '.report.txt';
+      }
     }
 
     if (data.externs) {

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -113,8 +113,10 @@ module.exports = function(grunt) {
           });
 
         });
-      } else if (data.report) {
-        grunt.log.error(stderr);
+      } else {
+        if (data.report) {
+          grunt.log.error(stderr);
+        }
         done();
       }
 

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -48,7 +48,10 @@ module.exports = function(grunt) {
 
     if (data.jsOutputFile) {
       command += ' --js_output_file ' + data.jsOutputFile;
-      reportFile = data.jsOutputFile + '.report.txt';
+    }
+
+    if (data.reportFile) {
+      reportFile = data.reportFile;
     }
 
     if (data.externs) {
@@ -110,6 +113,8 @@ module.exports = function(grunt) {
           });
 
         });
+      } else if (data.report) {
+        grunt.log.error(stderr);
       }
 
     });

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -115,6 +115,7 @@ module.exports = function(grunt) {
         });
       } else if (data.report) {
         grunt.log.error(stderr);
+        done();
       }
 
     });


### PR DESCRIPTION
Having an option to set the report file location is very important for us. By default report file is being generated in the same location as the compiled js. In our case that directory is for production deployment and we can't have log files there.

Building on LeZuse pull request #24, but leaving the default as it used to be. So: by default it generates the report in the same location. You may provide a custom reportFile path to save it in, say, your log directory. You may also set

``` javascript
reportFile: ''
```

to not log at all. In this case it does seem useful to log errors to console.
