### PR TITLE
Update closure-compiler.js

### DIFF
--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -36,27 +36,43 @@ module.exports = function(grunt) {
     var command = 'java -jar ' + closurePath + '/build/compiler.jar';
 
     data.cwd = data.cwd || './';
+    if(data.modules){
+  	//data.modules = grunt.file.expand(data.modules);
+		  for(var i=0;i<data.modules.length;i++)
+		  {
+		  	var js=grunt.file.expand({cwd:data.cwd},data.modules[i].js)
+			  command += ' --js ' + js.join(' --js ');
+			  command +=' --module '+data.modules[i].jsOutputFile+":"+js.length;
+		  	var realpath=data.options.module_output_path_prefix+data.modules[i].jsOutputFile+".js";
+			  if(!grunt.file.exists(realpath))grunt.file.write(realpath,"")
+		
+			  if(data.modules[i].dependence)
+		  	command+=":"+data.modules[i].dependence;
+			
+			}
+		}
+  	else{
 
-    data.js = grunt.file.expand({cwd: data.cwd}, data.js);
+      data.js = grunt.file.expand({cwd: data.cwd}, data.js);
 
     // Sanitize options passed.
-    if (!data.js.length) {
+      if (!data.js.length) {
       // This task requires a minima an input file.
       grunt.warn('Missing js property.');
       return false;
-    }
+      }
 
     // Build command line.
-    command += ' --js ' + data.js.join(' --js ');
+      command += ' --js ' + data.js.join(' --js ');
 
-    if (data.jsOutputFile) {
-      if (!grunt.file.isPathAbsolute(data.jsOutputFile)) {
-        data.jsOutputFile = path.resolve('./') + '/' + data.jsOutputFile;
+      if (data.jsOutputFile) {
+        if (!grunt.file.isPathAbsolute(data.jsOutputFile)) {
+          data.jsOutputFile = path.resolve('./') + '/' + data.jsOutputFile;
+        }
+        command += ' --js_output_file ' + data.jsOutputFile;
+        reportFile = data.reportFile || data.jsOutputFile + '.report.txt';
       }
-      command += ' --js_output_file ' + data.jsOutputFile;
-      reportFile = data.reportFile || data.jsOutputFile + '.report.txt';
     }
-
     if (data.externs) {
       data.externs = grunt.file.expand(data.externs);
       command += ' --externs ' + data.externs.join(' --externs ');


### PR DESCRIPTION
add multi modules compress function to closure-compiler.demo:
"closure-compiler": {
        all_in: {// can only compress to one file
          closurePath: './',
          js: ['dist/concat/Pre.js','src/js/Three.js'],
          jsOutputFile: 'dist/min/Pre.js',
          maxBuffer: 500,
          options: {
            compilation_level: 'ADVANCED_OPTIMIZATIONS'
          }
        },
        my: {//multi modules compress
          closurePath: './',
                  maxBuffer: 500,
          options: {
                compilation_level: 'ADVANCED_OPTIMIZATIONS',
        module_output_path_prefix: "dist/min/modules/"
          }
          modules:[
           {
             js: 'src/js/Three.js',
             jsOutputFile: 'Three'       //module name & filename
             },
          {
             js: "dist/concat/parts/Pre.js",
             jsOutputFile: 'Pre',
             dependence:"Three"     //name of depended module 
             }]}
