### PR TITLE
fix whitespace issues in compiler, JS and output paths

### DIFF
--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
       return false;
     }
 
-    var command = 'java -jar ' + closurePath + '/build/compiler.jar';
+    var command = 'java -jar "' + closurePath + '/build/compiler.jar"';
 
     data.cwd = data.cwd || './';
 
@@ -47,13 +47,13 @@ module.exports = function(grunt) {
     }
 
     // Build command line.
-    command += ' --js ' + data.js.join(' --js ');
+    command += ' --js "' + data.js.join('" --js "') + '"';
 
     if (data.jsOutputFile) {
       if (!grunt.file.isPathAbsolute(data.jsOutputFile)) {
         data.jsOutputFile = path.resolve('./') + '/' + data.jsOutputFile;
       }
-      command += ' --js_output_file ' + data.jsOutputFile;
+      command += ' --js_output_file "' + data.jsOutputFile + '"';
       reportFile = data.reportFile || data.jsOutputFile + '.report.txt';
     }
 


### PR DESCRIPTION
Currently, if the path to the compiler or any of the JS files contains whitespace, the task will fail with an error: 

```
Cannot read: Files
```

I've fixed it by quoting the cli path arguments. Tested under Linux and Windows.
