### PR TITLE
quote externs path names; #33 followup

### DIFF
--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
 
     if (data.externs) {
       data.externs = grunt.file.expand(data.externs);
-      command += ' --externs ' + data.externs.join(' --externs ');
+      command += ' --externs "' + data.externs.join('" --externs "') + '"';
 
       if (!data.externs.length) {
         delete data.externs;


### PR DESCRIPTION
Fixes the "file not found" error which is throw when a given extern's file path/name contains whitespace, same handling as the `--js` paths in PR #33.
