### PR TITLE
sourceMappingURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ grunt.initConfig({
       closurePath: '/src/to/closure-compiler',
       js: 'static/src/frontend.js',
       jsOutputFile: 'static/js/frontend.min.js',
+      sourceMap: true,
+      sourceMapUrl: true,
       maxBuffer: 500,
       options: {
         compilation_level: 'ADVANCED_OPTIMIZATIONS',
@@ -41,6 +43,10 @@ grunt.initConfig({
 `js` property is always required.
 
 If `jsOutputFile` property is set, the script will be minified and saved to the file specified. Otherwise it will be output to the command line.
+
+If the `sourceMap` property is set to a truthy value, the closure compiler flags --create_source_map and --source_map_format are set. If you pass this property a string value, the source map will use that string as the map name. Otherwise, boolean true assumes the file name with a .map extension.  The --source_map_format flag is set to V3.
+
+If the `sourceMapUrl` property is set to a truthy value, the sourceMappingURL comment is appended to the generated JS file. If you pass this property as a string value, the sourceMappingURL will be set to that value. Otherwise, boolean true assumes the file name with a .map extension.
 
 `maxBuffer` property
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ grunt.initConfig({
       closurePath: '/src/to/closure-compiler',
       js: 'static/src/frontend.js',
       jsOutputFile: 'static/js/frontend.min.js',
-      sourceMap: true,
       sourceMapUrl: true,
       maxBuffer: 500,
       options: {
         compilation_level: 'ADVANCED_OPTIMIZATIONS',
-        language_in: 'ECMASCRIPT5_STRICT'
+        language_in: 'ECMASCRIPT5_STRICT',
+        create_source_map: 'src.js.map'
       }
     }
   }
@@ -43,8 +43,6 @@ grunt.initConfig({
 `js` property is always required.
 
 If `jsOutputFile` property is set, the script will be minified and saved to the file specified. Otherwise it will be output to the command line.
-
-If the `sourceMap` property is set to a truthy value, the closure compiler flags --create_source_map and --source_map_format are set. If you pass this property a string value, the source map will use that string as the map name. Otherwise, boolean true assumes the file name with a .map extension.  The --source_map_format flag is set to V3.
 
 If the `sourceMapUrl` property is set to a truthy value, the sourceMappingURL comment is appended to the generated JS file. If you pass this property as a string value, the sourceMappingURL will be set to that value. Otherwise, boolean true assumes the file name with a .map extension.
 

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -96,7 +96,9 @@ module.exports = function(grunt) {
 
       // Check to see if we should add the source map comment to end of file
       if (data.sourceMapUrl && data.options.create_source_map) {
-        if (typeof data.sourceMapUrl == 'boolean') data.sourceMapUrl = path.basename(data.options.create_source_map);
+        if (typeof data.sourceMapUrl == 'boolean') {
+          data.sourceMapUrl = path.basename(data.options.create_source_map);
+        }
 
         fs.appendFile(data.jsOutputFile, '//# sourceMappingURL=' + data.sourceMapUrl, function (err) {
           grunt.log.writeln('Could not add sourceMappingURL!');

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -96,7 +96,7 @@ module.exports = function(grunt) {
 
       // Check to see if we should add the source map comment to end of file
       if (data.sourceMapUrl && data.options.create_source_map) {
-        if (typeof data.sourceMapUrl == 'boolean') data.sourceMapUrl = path.basename(data.jsOutputFile) + '.map';
+        if (typeof data.sourceMapUrl == 'boolean') data.sourceMapUrl = path.basename(data.options.create_source_map);
 
         fs.appendFile(data.jsOutputFile, '//# sourceMappingURL=' + data.sourceMapUrl, function (err) {
           grunt.log.writeln('Could not add sourceMappingURL!');

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -16,7 +16,8 @@ module.exports = function(grunt) {
     var closurePath = '',
         reportFile = '',
         data = this.data,
-        done = this.async();
+        done = this.async(),
+        sourceMapName;
 
     // Check for closure path.
     if (data.closurePath) {
@@ -48,6 +49,20 @@ module.exports = function(grunt) {
 
     // Build command line.
     command += ' --js "' + data.js.join('" --js "') + '"';
+
+    // Build Source Map
+    if (data.sourceMap) {
+      if (typeof data.sourceMap == 'boolean' && data.jsOutputFile) data.sourceMap = data.jsOutputFile + '.map';
+
+      if (!grunt.file.isPathAbsolute(data.sourceMap)) {
+        data.sourceMap = path.resolve('./') + '/' + data.sourceMap;
+      }
+
+      sourceMapName = path.basename(data.sourceMap);
+
+      command += ' --create_source_map "' + data.sourceMap + '"';
+      command += ' --source_map_format=V3';
+    }
 
     if (data.jsOutputFile) {
       if (!grunt.file.isPathAbsolute(data.jsOutputFile)) {
@@ -92,6 +107,15 @@ module.exports = function(grunt) {
       if (err) {
         grunt.warn(err);
         done(false);
+      }
+
+      // Check to see if we should add the source map comment to end of file
+      if (data.sourceMap && data.sourceMapUrl) {
+        if (typeof data.sourceMapUrl == 'boolean') data.sourceMapUrl = sourceMapName;
+
+        fs.appendFile(data.jsOutputFile, '//# sourceMappingURL=' + data.sourceMapUrl, function (err) {
+          grunt.log.writeln('Could not add sourceMappingURL!');
+        });
       }
 
       if (stdout) {

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -16,8 +16,7 @@ module.exports = function(grunt) {
     var closurePath = '',
         reportFile = '',
         data = this.data,
-        done = this.async(),
-        sourceMapName;
+        done = this.async();
 
     // Check for closure path.
     if (data.closurePath) {
@@ -49,20 +48,6 @@ module.exports = function(grunt) {
 
     // Build command line.
     command += ' --js "' + data.js.join('" --js "') + '"';
-
-    // Build Source Map
-    if (data.sourceMap) {
-      if (typeof data.sourceMap == 'boolean' && data.jsOutputFile) data.sourceMap = data.jsOutputFile + '.map';
-
-      if (!grunt.file.isPathAbsolute(data.sourceMap)) {
-        data.sourceMap = path.resolve('./') + '/' + data.sourceMap;
-      }
-
-      sourceMapName = path.basename(data.sourceMap);
-
-      command += ' --create_source_map "' + data.sourceMap + '"';
-      command += ' --source_map_format=V3';
-    }
 
     if (data.jsOutputFile) {
       if (!grunt.file.isPathAbsolute(data.jsOutputFile)) {
@@ -110,8 +95,8 @@ module.exports = function(grunt) {
       }
 
       // Check to see if we should add the source map comment to end of file
-      if (data.sourceMap && data.sourceMapUrl) {
-        if (typeof data.sourceMapUrl == 'boolean') data.sourceMapUrl = sourceMapName;
+      if (data.sourceMapUrl && data.options.create_source_map) {
+        if (typeof data.sourceMapUrl == 'boolean') data.sourceMapUrl = path.basename(data.jsOutputFile) + '.map';
 
         fs.appendFile(data.jsOutputFile, '//# sourceMappingURL=' + data.sourceMapUrl, function (err) {
           grunt.log.writeln('Could not add sourceMappingURL!');


### PR DESCRIPTION
This option allows you to automatically append the sourceMappingURL comment to the generated JS file.  Currently, an option to do this by default in Closure Compiler.

The generated comment will look something like this at the end of the JS file:

```
//# sourceMappingURL=file.js.map
```

The sourceMapUrl option can be boolean true if you want to match the generated file's name or you can specify a string and name it whatever you'd like.
