### PR TITLE
Adding --module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,36 @@ grunt.initConfig({
   }
 });
 ```
+### `modules` property
+Closure compiler can be used to procude multiple JS files, using the --module parameter and related ones. These modules can have dependencies, can be the result of multiple JS source files, and can be wrapped. The ```jsOutputFile``` parameter is useless using modules, but a directory can be specified using ```output_path_prefix```.
+#### Parameters
+```output_path_prefix``` specifies a prefix to append to the output files. Can be either a directory or just a string.
+
+```definitions``` must contain the description of each module. Available parameters are:
 
 
+
+- ```files``` : (Required) Array of source file to in clude in the module
+- ```dependencies``` : (Optional) Array of modules it depends on. If ModuleB requires ModuleA, then ModuleB definition must include ```dependencies:['ModuleA']```.
+- ```wrapper``` : (Optional) string to wrap the resulting module code in. Placeholder for the code is %s. module name can be inserted using the placeholder %basename% (please refer to Closure Compiler documentation for more detailed information on wrapping).
+
+    
+    	modules: {
+            output_path_prefix: '.\\compiled\\',
+            definitions: {
+                'Core':{
+                    files:['src\\builder.js','src\\events.js','src\\plugins.js','src\\storage.js','src\\core.js','src\\main.js'],
+                    dependencies:[],
+                    wrapper:'(function(){ %s }).call(window);'
+                },
+                'sample':{
+                    files:['src\\plugins\\sample.js'],
+                    dependencies:['Core'],
+                    wrapper:'(function(){ %s }).call(window);'
+                }
+            }
+        }
+```
 ## Note
 
 grunt-closure-compiler initial development was founded by [Dijiwan](http://www.dijiwan.com/).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ grunt.initConfig({
 });
 ```
 
+`closureCompiler`: (Optional) can be set to the closure compiler Path, if it has not been installed from sources.
+
 `js` property is always required.
 
 If `jsOutputFile` property is set, the script will be minified and saved to the file specified. Otherwise it will be output to the command line.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ A Grunt task for [Closure Compiler](https://developers.google.com/closure/compil
 
 ## Getting Started
 
-First you need to download a [build of Closure Compiler](http://code.google.com/p/closure-compiler/downloads/list) or build it [from the source](http://code.google.com/p/closure-compiler/source/checkout) (see [details below](#closure-compiler-installation-from-source)).
-
-Optionally, you can set up an environment variable called `CLOSURE_PATH` that points to your Closure Compiler dir (see [details below](#set-up-the-environment-variable)).
-
 Install this module on your project's [grunt.js gruntfile](https://github.com/cowboy/grunt/blob/master/docs/getting_started.md):
 ```bash
 $ npm install grunt-closure-compiler
@@ -23,7 +19,6 @@ Then you can minify JavaScript calling:
 grunt.initConfig({
   'closure-compiler': {
     frontend: {
-      closurePath: '/src/to/closure-compiler',
       js: 'static/src/frontend.js',
       jsOutputFile: 'static/js/frontend.min.js',
       maxBuffer: 500,
@@ -35,8 +30,6 @@ grunt.initConfig({
   }
 });
 ```
-
-`closurePath` is required if you choose not to set up the `CLOSURE_PATH` environment variable. In this case, it should point to the install dir of Closure Compiler (not the subdirectory where the `compiler.jar` file is located).
 
 `js` property is always required.
 
@@ -53,57 +46,9 @@ Optionally, several parameters can be passed to `options` object.
 
 ## Documentation
 
-### Closure Compiler installation from source
+### Specify the Closure Compiler Version
 
-Install dependencies:
-```bash
-$ sudo apt-get install git ant openjdk-7-jdk
-```
-
-Then checkout the source from Git and build:
-```bash
-$ git clone https://code.google.com/p/closure-compiler/
-$ cd closure-compiler
-$ ant
-```
-
-To refresh your build, simply call:
-```bash
-$ git pull
-$ ant clean
-$ ant
-```
-
-#### Mac
-
-Mac users can install it from brew:
-```bash
-$ brew install closure-compiler
-```
-
-### Set up the environment variable
-
-Setting up a `CLOSURE_PATH` environment variable is preferred because:
-
-* You don't have to specify the `closurePath` each time.
-* It makes it easy to use contributed externs.
-
-In case you're wondering, Closure Compiler utilizes continuous integration, so it's unlikely to break.
-
-If you create the `CLOSURE_PATH` environment variable, make sure to have it pointing to the `closure-compiler` dir created earlier (and not to the `build` subdirectory where the jar is located).
-
-#### Mac
-
-On Mac, when installed with brew, you can get the install path using:
-```bash
-$ brew --prefix closure-compiler
-/usr/local/Cellar/closure-compiler/20120710
-```
-
-Just append `/libexec` to what you get. In this example, you should use the following path:
-```
-/usr/local/Cellar/closure-compiler/20120710/libexec/
-```
+Closure-compiler is [distributed via NPM](https://www.npmjs.com/package/google-closure-compiler). You may specify the version of Closure-compiler used in your package.json.
 
 ### Minification report
 
@@ -169,31 +114,17 @@ grunt.initConfig({
 });
 ```
 
-When defining externs, if you added the `CLOSURE_PATH` environment variable you can easily reference Closure Compiler builtin externs using `<%= process.env.CLOSURE_PATH %>` Grunt template:
+When using externs, you can easily reference Closure Compiler contributed externs which are distributed as part of the NPM package:
 ```javascript
-grunt.initConfig({
-  'closure-compiler': {
-    frontend: {
-      js: 'static/src/frontend.js',
-      jsOutputFile: 'static/js/frontend.min.js',
-      options: {
-        externs: '<%= process.env.CLOSURE_PATH %>/contrib/externs/jquery-1.7.js',
-      }
-    }
-  }
-});
-```
+var closurePath = require.resolve('google-closure-compiler').replace(/package\.json$/, '');
 
-Otherwise, use the `<%= %>` Grunt template:
-```javascript
 grunt.initConfig({
   'closure-compiler': {
     frontend: {
-      closurePath: '/src/to/closure-compiler',
       js: 'static/src/frontend.js',
       jsOutputFile: 'static/js/frontend.min.js',
       options: {
-        externs: '<%= closure-compiler.frontend.closurePath %>/contrib/externs/jquery-1.7.js'
+        externs: '<%= closurePath %>/contrib/externs/jquery-1.7.js',
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "google-closure-compiler": ">=20150315.0.2",
     "grunt": "~0.4.0"
   },
   "keywords": [

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -5,35 +5,24 @@ module.exports = function(grunt) {
     var exec = require('child_process').exec,
         fs = require('fs'),
         path = require('path'),
-        gzip = require('zlib').gzip;
+        gzip = require('zlib').gzip,
+		closurePath = require.resolve('google-closure-compiler');
 
+	if (closurePath) {
+		closurePath = closurePath.replace(/package\.json$/, 'compiler.jar');
+	}
+	
     // ==========================================================================
     // TASKS
     // ==========================================================================
 
     grunt.registerMultiTask('closure-compiler', 'Minify JS files using Closure Compiler.', function() {
 
-        var closurePath = '',
-            reportFile = '',
+        var reportFile = '',
             data = this.data,
             done = this.async();
 
-        // Check for closure path.
-        if (data.closurePath) {
-            closurePath = data.closurePath;
-        } else if (process.env.CLOSURE_PATH) {
-            closurePath = process.env.CLOSURE_PATH;
-        } else {
-            grunt.log.error('' +
-                '/!\\'.red +
-                ' Set an environment variable called ' +
-                'CLOSURE_PATH'.red + ' or the build parameter' + 'closurePath'.red +
-                ' and\nmake it point to your root install of Closure Compiler.' +
-                '\n');
-            return false;
-        }
-
-        var command = 'java -jar "' + closurePath + '/build/compiler.jar"';
+        var command = 'java -jar "' + closurePath + '"';
         data.cwd = data.cwd || './';
 
         data.js = grunt.file.expand({cwd: data.cwd}, data.js||[]);

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
             }
         }
 
-        if (data.options.externs) {
+        if (data.options && data.options.externs) {
             data.options.externs = grunt.file.expand(data.options.externs);
 
             if (!data.options.externs.length) {

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -1,151 +1,184 @@
 module.exports = function(grunt) {
 
-  'use strict';
+    'use strict';
 
-  var exec = require('child_process').exec,
-      fs = require('fs'),
-      path = require('path'),
-      gzip = require('zlib').gzip;
+    var exec = require('child_process').exec,
+        fs = require('fs'),
+        path = require('path'),
+        gzip = require('zlib').gzip;
 
-  // ==========================================================================
-  // TASKS
-  // ==========================================================================
+    // ==========================================================================
+    // TASKS
+    // ==========================================================================
 
-  grunt.registerMultiTask('closure-compiler', 'Minify JS files using Closure Compiler.', function() {
+    grunt.registerMultiTask('closure-compiler', 'Minify JS files using Closure Compiler.', function() {
 
-    var closurePath = '',
-        reportFile = '',
-        data = this.data,
-        done = this.async();
+        var closurePath = '',
+            reportFile = '',
+            data = this.data,
+            done = this.async();
 
-    // Check for closure path.
-    if (data.closurePath) {
-      closurePath = data.closurePath;
-    } else if (process.env.CLOSURE_PATH) {
-      closurePath = process.env.CLOSURE_PATH;
-    } else {
-      grunt.log.error('' +
-          '/!\\'.red +
-          ' Set an environment variable called ' +
-          'CLOSURE_PATH'.red + ' or the build parameter' + 'closurePath'.red +
-          ' and\nmake it point to your root install of Closure Compiler.' +
-          '\n');
-      return false;
-    }
+        // Check for closure path.
+        if (data.closurePath) {
+            closurePath = data.closurePath;
+        } else if (process.env.CLOSURE_PATH) {
+            closurePath = process.env.CLOSURE_PATH;
+        } else {
+            grunt.log.error('' +
+                '/!\\'.red +
+                ' Set an environment variable called ' +
+                'CLOSURE_PATH'.red + ' or the build parameter' + 'closurePath'.red +
+                ' and\nmake it point to your root install of Closure Compiler.' +
+                '\n');
+            return false;
+        }
 
-    var command = 'java -jar "' + closurePath + '/build/compiler.jar"';
+        var command = 'java -jar "' + closurePath + '/build/compiler.jar"';
+        data.cwd = data.cwd || './';
 
-    data.cwd = data.cwd || './';
+        data.js = grunt.file.expand({cwd: data.cwd}, data.js||[]);
 
-    data.js = grunt.file.expand({cwd: data.cwd}, data.js);
+        // Sanitize options passed.
+        if (!data.js.length&&!data.modules) {
+            // This task requires a minima an input file.
+            grunt.warn('Missing js property.');
+            return false;
+        }
+        // Build command line.
+        //case : js parameter passed (no module then)
+        if(data.js && data.js.length && data.js.length>0) {
 
-    // Sanitize options passed.
-    if (!data.js.length) {
-      // This task requires a minima an input file.
-      grunt.warn('Missing js property.');
-      return false;
-    }
+            command += ' --js "' + data.js.join('" --js "') + '"';
+            if (data.jsOutputFile) {
+                if (!grunt.file.isPathAbsolute(data.jsOutputFile)) {
+                    data.jsOutputFile = path.resolve('./') + '/' + data.jsOutputFile;
+                }
+                command += ' --js_output_file "' + data.jsOutputFile + '"';
+                reportFile = data.reportFile || data.jsOutputFile + '.report.txt';
+            }
+        }
 
-    // Build command line.
-    command += ' --js "' + data.js.join('" --js "') + '"';
+        if (data.externs) {
+            data.externs = grunt.file.expand(data.externs);
+            command += ' --externs ' + data.externs.join(' --externs ');
 
-    if (data.jsOutputFile) {
-      if (!grunt.file.isPathAbsolute(data.jsOutputFile)) {
-        data.jsOutputFile = path.resolve('./') + '/' + data.jsOutputFile;
-      }
-      command += ' --js_output_file "' + data.jsOutputFile + '"';
-      reportFile = data.reportFile || data.jsOutputFile + '.report.txt';
-    }
+            if (!data.externs.length) {
+                delete data.externs;
+            }
+        }
 
-    if (data.externs) {
-      data.externs = grunt.file.expand(data.externs);
-      command += ' --externs ' + data.externs.join(' --externs ');
+        if (data.options.externs) {
+            data.options.externs = grunt.file.expand(data.options.externs);
 
-      if (!data.externs.length) {
-        delete data.externs;
-      }
-    }
+            if (!data.options.externs.length) {
+                delete data.options.externs;
+            }
+        }
+        //adding module compilation support
+        if(data.modules){
+            if(data.modules.output_path_prefix){
+                command += ' --module_output_path_prefix ' + data.modules.output_path_prefix+' ';
+            }
+            if(data.modules.definitions){
+                for(var module in data.modules.definitions){
+                    for(var fileIndex = 0;fileIndex<data.modules.definitions[module].files.length;fileIndex++){
+                        command += ' --js ' +data.modules.definitions[module].files[fileIndex]+' ';
+                    }
+                    command += ' --module '+module+':'+data.modules.definitions[module].files.length;
+                    if(data.modules.definitions[module].dependencies && data.modules.definitions[module].dependencies.length>0){
+                        command+=':'+data.modules.definitions[module].dependencies.join(',');
+                    }
+                    command+= ' ';
+                    if(data.modules.definitions[module].wrapper){
+                        command+='--module_wrapper '+module+':"'+data.modules.definitions[module].wrapper+'" ';
+                    }
+                }
 
-    if (data.options.externs) {
-      data.options.externs = grunt.file.expand(data.options.externs);
+            }
 
-      if (!data.options.externs.length) {
-        delete data.options.externs;
-      }
-    }
+        }
 
-    for (var directive in data.options) {
-      if (Array.isArray(data.options[directive])) {
-        command += ' --' + directive + ' ' + data.options[directive].join(' --' + directive + ' ');
-      } else if (data.options[directive] === undefined || data.options[directive] === null) {
-        command += ' --' + directive;
-      } else {
-        command += ' --' + directive + ' "' + String(data.options[directive]) + '"';
-      }
-    }
+        for (var directive in data.options) {
+            if (Array.isArray(data.options[directive])) {
+                command += ' --' + directive + ' ' + data.options[directive].join(' --' + directive + ' ');
+            } else if (data.options[directive] === undefined || data.options[directive] === null) {
+                command += ' --' + directive;
+            } else {
+                command += ' --' + directive + ' "' + String(data.options[directive]) + '"';
+            }
+        }
 
-    // because closure compiler does not create dirs.
-    grunt.file.write(data.jsOutputFile, '');
+        // because closure compiler does not create dirs.
+        if(data.jsOutputFile){
+            grunt.file.write(data.jsOutputFile, '');
+        }
+        else{
+            if(data.modules.output_path_prefix){
+                grunt.file.write('./'+data.modules.output_path_prefix+'/.tmp', '');
+            }
+        }
 
-    // Minify WebGraph class.
-    exec(command, { maxBuffer: data.maxBuffer * 1024, cwd: data.cwd }, function(err, stdout, stderr) {
-      if (err) {
-        grunt.warn(err);
-        done(false);
-      }
+console.log(command);
 
-      if (stdout) {
-        grunt.log.writeln(stdout);
-      }
-
-      // If OK, calculate gzipped file size.
-      if (reportFile.length) {
-        var min = fs.readFileSync(data.jsOutputFile, 'utf8');
-        min_info(min, function(err) {
-          if (err) {
-            grunt.warn(err);
-            done(false);
-          }
-
-          if (data.noreport) {
-            done();
-          } else {
-            // Write compile report to a file.
-            fs.writeFile(reportFile, stderr, function(err) {
-              if (err) {
+        // Minify WebGraph class.
+        exec(command, { maxBuffer: data.maxBuffer * 1024, cwd: data.cwd }, function(err, stdout, stderr) {
+            if (err) {
                 grunt.warn(err);
                 done(false);
-              }
+            }
 
-              grunt.log.writeln('A report is saved in ' + reportFile + '.');
-              done();
-            });
-          }
+            if (stdout) {
+                grunt.log.writeln(stdout);
+            }
+
+            // If OK, calculate gzipped file size.
+            if (reportFile.length) {
+                var min = fs.readFileSync(data.jsOutputFile, 'utf8');
+                min_info(min, function(err) {
+                    if (err) {
+                        grunt.warn(err);
+                        done(false);
+                    }
+
+                    if (data.noreport) {
+                        done();
+                    } else {
+                        // Write compile report to a file.
+                        fs.writeFile(reportFile, stderr, function(err) {
+                            if (err) {
+                                grunt.warn(err);
+                                done(false);
+                            }
+
+                            grunt.log.writeln('A report is saved in ' + reportFile + '.');
+                            done();
+                        });
+                    }
+
+                });
+            } else {
+                if (data.report) {
+                    grunt.log.error(stderr);
+                }
+                done();
+            }
 
         });
-      } else {
-        if (data.report) {
-          grunt.log.error(stderr);
-        }
-        done();
-      }
 
     });
 
-  });
+    // Output some size info about a file.
+    function min_info(min, onComplete) {
+        gzip(min, function(err, buffer) {
+            if (err) {
+                onComplete.call(this, err);
+            }
 
-  // Output some size info about a file.
-  function min_info(min, onComplete) {
-    gzip(min, function(err, buffer) {
-      if (err) {
-        onComplete.call(this, err);
-      }
+            var gzipSize = buffer.toString().length;
+            grunt.log.writeln('Compressed size: ' + String((gzipSize / 1024).toFixed(2)).green + ' kb gzipped (' + String(gzipSize).green + ' bytes).');
 
-      var gzipSize = buffer.toString().length;
-      grunt.log.writeln('Compressed size: ' + String((gzipSize / 1024).toFixed(2)).green + ' kb gzipped (' + String(gzipSize).green + ' bytes).');
-
-      onComplete.call(this, null);
-    });
-  }
+            onComplete.call(this, null);
+        });
+    }
 
 };

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
             done = this.async();
         
         if(data.closurePath){
-            closurePath = data.closurePath + '/compiler.jar';
+            closurePath = data.closurePath + 'compiler.jar';
         }
             
         var command = 'java -jar "' + closurePath + '"';

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -1,4 +1,4 @@
-el cmodule.exports = function(grunt) {
+module.exports = function(grunt) {
 
     'use strict';
 

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -1,4 +1,4 @@
-module.exports = function(grunt) {
+el cmodule.exports = function(grunt) {
 
     'use strict';
 
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
             done = this.async();
         
         if(data.closurePath){
-            closurePath = closurePath + '/compiler.jar';
+            closurePath = data.closurePath + '/compiler.jar';
         }
             
         var command = 'java -jar "' + closurePath + '"';

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -21,7 +21,11 @@ module.exports = function(grunt) {
         var reportFile = '',
             data = this.data,
             done = this.async();
-
+        
+        if(data.closurePath){
+            closurePath = closurePath + '/compiler.jar';
+        }
+            
         var command = 'java -jar "' + closurePath + '"';
         data.cwd = data.cwd || './';
 


### PR DESCRIPTION
--modules gives the possibility to compile different js files in the same context.

Added it in the task and in the documentation. The syntax is pretty straight-forward. Closure provides some other options for modules I didn't include as I never used them.
