### PR TITLE
add optional jarPath setting - complete path to .jar file

### DIFF
--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -14,6 +14,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('closure-compiler', 'Minify JS files using Closure Compiler.', function() {
 
     var closurePath = '',
+        jarPath = '',
         reportFile = '',
         data = this.data,
         done = this.async();
@@ -33,7 +34,8 @@ module.exports = function(grunt) {
       return false;
     }
 
-    var command = 'java -jar "' + closurePath + '/build/compiler.jar"';
+    var jarPath = data.jarPath || ( closurePath + '/build/compiler.jar' );
+    var command = 'java -jar "' + jarPath + '"';
 
     data.cwd = data.cwd || './';
 


### PR DESCRIPTION
adds optional `jarPath` setting - complete path to .jar file

if present, it should be a complete path (including filename) to the jar file
if not, the original `closurePath + '/build/compiler.jar'` is used

example (needed in debian):

```
        'closure-compiler': {
            frontend: {
                closurePath: '/usr/bin/closure-compiler',
                jarPath: '/usr/share/java/closure-compiler.jar',
                js: 'js/*.js',
                ...
            }
        }
```

it is an (IMHO simpler) alternative to pull request #36
