### PR TITLE
Made the java binary location customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,30 @@ You can specify the path and name where the report will be saved using the `repo
 
 To deactivate report creation, set `noreport` to `true`.
 
+### `javaBin` property
+
+The default JVM on your system will be used to run the closure compiler. For most users, this will be a 64-bit JVM. The closure compiler is much faster when run with a 32bit JVM and in client mode. You can read more about this at the [closure compiler FAQ](https://code.google.com/p/closure-compiler/wiki/FAQ).
+
+Rather than deal with the hassle of trying to run multiple versions of the JVM it is simpler to download it to a directory and without modifying any environment variables, call the java binary using an absolute path.
+
+You can download a 32bit version of java from here: http://www.oracle.com/technetwork/java/javase/downloads/index.html. As an example, download the Java SE 8 JDK, extract the contents and move the directory to the desired location such as `/opt` in a linux environment. You will end up with a path such as `/opt/jdk1.8.0_20`.
+
+You can then use the javaBin property to specify a custom java binary command such as:
+
+```javascript
+grunt.initConfig({
+  'closure-compiler': {
+    frontend: {
+      javaBin: '/opt/jdk1.8.0_20/bin/java -client -d32',
+      js: 'static/src/frontend.js',
+      jsOutputFile: 'static/js/frontend.min.js',
+    }
+  }
+})
+```
+
+It is not unusual to gain an order of magnitude gain in performance when compiling many files in this way.
+
 ### `js` property
 
 This task is a [multi task](https://github.com/cowboy/grunt/blob/master/docs/types_of_tasks.md), you can specify several targets. The task can minify many scripts at a time.

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -33,7 +33,8 @@ module.exports = function(grunt) {
       return false;
     }
 
-    var command = 'java -jar "' + closurePath + '/build/compiler.jar"';
+    var javaBin = data.javaBin || 'java';
+    var command = javaBin + ' -jar "' + closurePath + '/build/compiler.jar"';
 
     data.cwd = data.cwd || './';
 


### PR DESCRIPTION
Closure compiler docs (https://code.google.com/p/closure-compiler/wiki/FAQ) recommend the use of 32bit JVM for performance improvements.

I was able to improve my project compile time from 70 seconds to 15 seconds by using their recommendations. The problem is the java binary is hard coded to use your system default.

This is not ideal because most people would be running a 64bit JVM and the 32bit JVM would only be used for a specific purpose, so trying to run a 32 bit JVM alongside a 64bit one would take a lot of tinkering.

With this patch you can specify this in the grunt task config:

```
{
    javaBin: '/opt/jdk1.8.0_20/bin/java -client -d32',
    closurePath: ...,
}
```

You can download any JDK and place it somewhere on the system and without setting any environment variables or editing anything etc, you can use it just for doing the compiling to gain the speed increase.

Also, is there any reason this.options() is not used in the task? Seems it would be more efficient for this.
