### PR TITLE
externs configuration fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-closure-compiler",
   "description": "A Grunt task for Closure Compiler.",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "homepage": "https://github.com/gmarty/grunt-closure-compiler",
   "author": {
     "name": "Guillaume Marty",

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -58,7 +58,7 @@ module.exports = function(grunt) {
     }
 
     if (data.externs) {
-      data.externs = grunt.file.expand(data.externs);
+      data.externs = grunt.file.expand({cwd: data.cwd}, data.externs);
       command += ' --externs ' + data.externs.join(' --externs ');
 
       if (!data.externs.length) {
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
     }
 
     if (data.options.externs) {
-      data.options.externs = grunt.file.expand(data.options.externs);
+      data.options.externs = grunt.file.expand({cwd: data.cwd}, data.options.externs);
 
       if (!data.options.externs.length) {
         delete data.options.externs;

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -59,10 +59,11 @@ module.exports = function(grunt) {
 
     if (data.externs) {
       data.externs = grunt.file.expand({cwd: data.cwd}, data.externs);
-      command += ' --externs ' + data.externs.join(' --externs ');
 
       if (!data.externs.length) {
         delete data.externs;
+      } else {
+        command += ' --externs ' + data.externs.join(' --externs ');
       }
     }
 


### PR DESCRIPTION
Attempt to use options.externs with relative paths causes malformed command line with warnings a la "Warning: Command failed: ERROR - Cannot read: --compilation_level"
