### PR TITLE
Update grunt to latest.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,5 +33,5 @@ module.exports = function(grunt) {
   grunt.loadTasks('tasks');
 
   // Default task.
-  grunt.registerTask('default', 'lint test');
+  grunt.registerTask('default', ['lint', 'test']);
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-closure-compiler",
   "description": "A Grunt task for Closure Compiler.",
-  "version": "0.0.21",
+  "version": "1.0.0",
   "homepage": "https://github.com/gmarty/grunt-closure-compiler",
   "author": {
     "name": "Guillaume Marty",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt": "^1.0.1"
+    "grunt": "1.0.1"
   },
   "keywords": [
     "Closure Compiler",

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "grunt-closure-compiler": "bin/grunt-closure-compiler"
   },
   "engines": {
-    "node": ">=0.6.0"
+    "node": ">=7.0.0"
   },
   "scripts": {
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt": "~0.4.0"
+    "grunt": "^1.0.1"
   },
   "keywords": [
     "Closure Compiler",


### PR DESCRIPTION
Update grunt to latest, and node dependency to node 7.

@gmarty Staying on an old version of node gives all users of grunt-closure-compiler the following warnings:

npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.

Any chance we can update to a newer version of grunt (which would fix this)?